### PR TITLE
EditorConfig for Coding Standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,283 @@
+# Copyright 2024 Xeno Innovations, Inc.
+# https://github.com/xenoinc/CodeDevOps
+# Revision: 6.2
+#
+# This EditorConfig file provides consistant coding styles and formatting
+# structures for your team's projects while preserving your personal defaults.
+#
+# Revision Log
+# 6.2 2024-04-06 - Custom rules for Doom port
+# 6.1 2022-01-21 - Updated rules to include StyleCopAnalyzers. Added Static Readonly PascalCase from _camelCase.
+# 6.0 2022-01-10 - Included defaults from Microsoft to override custom settings
+# 5.2 2021-10-11 - Uniform C# spacing rules and labeled code formatting rules
+# 5.1 2021-09-14 - Added PowerShell and Markdown rules
+# 5   2021-08-26 - C# StyleCop rules
+# 4a  2021-01-17 - C# StyleCop rules
+# 4   2020-05-10 - C# coding standards
+# 3c  2020-04-18 - Split file filters into their own sections
+# 3b  2019-03-24 - Included additional rules
+# 3   2017-07-31 - Basic
+#
+# References:
+# - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
+# - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+#   - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
+#   - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules
+#   - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+# - https://github.com/dotnet/roslyn/blob/main/.editorconfig
+# - https://github.com/microsoft/microsoft-ui-xaml/blob/master/.editorconfig
+#
+
+# Top-most EditorConfig file
+root = true
+
+# All generic files should use MSDOS style endings, not Unix (lf)
+[*]
+end_of_line = crlf
+indent_style = space
+
+[*.{cs,csx}]
+indent_style = space
+indent_size = 4
+tab_width = 4
+charset = utf-8-bom
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sln]
+indent_size = 2
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# YAML files
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# C# Ruleset
+[*.{cs,csx}]
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+## Formatting - new line options
+### Require braces to be on a new line for (also known as "Allman" style)
+### accessors, methods, object_collection, control_blocks, types, properties, lambdas
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+## Spaces
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Organize Usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = unset
+# file_header_template = Copyright Xeno Innovations, Inc. 2022\nSee the LICENSE file in the project root for more information.
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+dotnet_style_readonly_field = true
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+#dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = true:warning
+
+# dotnet_diagnostic.IDE2001.severity = none
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+
+# dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+
+# dotnet_diagnostic.IDE2003.severity = error
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+# Naming Conventions
+## Async methods must use "Async" suffix
+dotnet_naming_rule.async_methods_end_in_async.symbols = any_async_methods
+dotnet_naming_rule.async_methods_end_in_async.style = end_in_async
+dotnet_naming_rule.async_methods_end_in_async.severity = error
+dotnet_naming_symbols.any_async_methods.applicable_kinds = method
+dotnet_naming_symbols.any_async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.any_async_methods.required_modifiers = async
+dotnet_naming_style.end_in_async.capitalization = pascal_case
+dotnet_naming_style.end_in_async.required_prefix =
+dotnet_naming_style.end_in_async.required_suffix = Async
+dotnet_naming_style.end_in_async.word_separator =
+
+## private fields must prefix with an underscore
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = error
+dotnet_naming_symbols.private_fields.applicable_kinds       = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+## private static fields must use PascalCase (overrides '_' based on SA1311)
+dotnet_naming_rule.private_static_field_naming.symbols  = private_static_field_naming
+dotnet_naming_rule.private_static_field_naming.style    = pascal_case_style
+dotnet_naming_rule.private_static_field_naming.severity = error
+dotnet_naming_symbols.private_static_field_naming.applicable_kinds   = field
+dotnet_naming_symbols.private_static_field_naming.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_field_naming.required_modifiers = static, readonly
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+## Constant fields must use PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = error
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+dotnet_naming_style.pascal_case_style.capitalization              = pascal_case
+
+## Interfaces must have an I suffix
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+
+## Types and Non-Field Members must be PascalCase
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+## Code Style Rules
+# IDE1005: Use conditional delegate call
+csharp_style_conditional_delegate_call = true
+# IDE1005: Delegate invocation can be simplified.
+dotnet_diagnostic.IDE1005.severity = warning
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = none
+# IDEOOO8: Use of var
+dotnet_diagnostic.IDE0008.severity = none
+# IDE0010: Add missing cases
+dotnet_diagnostic.IDE0010.severity = none
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline
+# IDE0025: Use expression body for properties
+csharp_style_expression_bodied_properties = true
+# IDE0026: Use expression body for indexers
+csharp_style_expression_bodied_indexers = true
+# IDE0027: Use expression body for accessors
+csharp_style_expression_bodied_accessors = true
+# IDE0046: Convert to conditional expression
+dotnet_diagnostic.IDE0046.severity = none
+# IDE0058: Expression value is never used
+# csharp_style_unused_value_expression_statement_preference = discard_variable
+dotnet_diagnostic.IDE0058.severity = none
+
+## Code Quality Rules
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.CA1031.severity = none
+# CA1822: Mark members as static
+##dotnet_diagnostic.CA1822.severity = none
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = error
+
+## Compiler
+# CS0618: Type or member is obsolete
+dotnet_diagnostic.CS0618.severity = error
+##dotnet_diagnostic.CS0618.severity = warning
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = silent
+

--- a/GamePlay.md
+++ b/GamePlay.md
@@ -2,6 +2,8 @@
 
 Getting started, keyboard map, cheat codes, and reference documents.
 
+The check out the official [DOOM source](https://github.com/id-Software/DOOM) for more information.
+
 ## Getting Started
 
 If you own Doom already, add one of the following approved `WAD` files in the same folder as `managed-doom.exe`.
@@ -23,7 +25,7 @@ If you own Doom already, add one of the following approved `WAD` files in the sa
 
 | | | |
 |-|-|-|
-| `F1` = Help               | `F2` = Save              | `F3` = Load 
+| `F1` = Help               | `F2` = Save              | `F3` = Load
 | `F4` = Sound Volume       | `F5` = Detail            | `F6` = Quick Save
 | `F7` = End Game           | `F8` = Messages          | `F9` = Quick Load
 | `F10` = Quit              | `F11` = Gamma Correction |
@@ -77,6 +79,7 @@ If you own Doom already, add one of the following approved `WAD` files in the sa
 
 ## More Info
 
+* https://github.com/id-Software/DOOM
 * https://doomwiki.org/wiki/Entryway
 * https://doomwiki.org/wiki/IWAD
   * Shareware - https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad


### PR DESCRIPTION
Added the `.editorconfig` file to maintain the project's custom coding standards across multiple developer environments.

As the old saying goes, no 2 devs code the same.