### PR TITLE
Cheat - Display Position (IDMYPOS)

### DIFF
--- a/ManagedDoom/src/Doom/World/Cheat.cs
+++ b/ManagedDoom/src/Doom/World/Cheat.cs
@@ -33,12 +33,12 @@ namespace ManagedDoom
             new CheatInfo("idbehold", (cheat, typed) => cheat.ShowPowerUpList(), false),
             new CheatInfo("idbehold?", (cheat, typed) => cheat.DoPowerUp(typed), false),
             new CheatInfo("idchoppers", (cheat, typed) => cheat.GiveChainsaw(), false),
+            new CheatInfo("idmypos", (cheat, typed) => cheat.ShowMyPosition(), false),
             new CheatInfo("tntem", (cheat, typed) => cheat.KillMonsters(), false),
             new CheatInfo("killem", (cheat, typed) => cheat.KillMonsters(), false),
             new CheatInfo("fhhall", (cheat, typed) => cheat.KillMonsters(), false),
             new CheatInfo("idclev??", (cheat, typed) => cheat.ChangeLevel(typed), true),
             new CheatInfo("idmus??", (cheat, typed) => cheat.ChangeMusic(typed), false),
-            new CheatInfo("idmypos", (cheat, typed) => cheat.ShowMyPosition(), false),
         };
 
         private static readonly int maxCodeLength = list.Max(info => info.Code.Length);

--- a/ManagedDoom/src/Doom/World/Cheat.cs
+++ b/ManagedDoom/src/Doom/World/Cheat.cs
@@ -206,9 +206,12 @@ namespace ManagedDoom
             world.AutoMap.ToggleCheat();
         }
 
+        /// <summary>Display the player's current position.</summary>
         private void ShowMyPosition()
         {
-          ////
+            var player = world.ConsolePlayer;
+            var buf = $"ang=0x{player.Mobj.Angle:X4};x,y=(0x{player.Mobj.X:X4},0x{player.Mobj.Y:X4})";
+            player.SendMessage(buf);
         }
 
         private void ShowPowerUpList()
@@ -414,8 +417,6 @@ namespace ManagedDoom
             world.Options.Music.StartMusic(Map.GetMapBgm(options), true);
             world.ConsolePlayer.SendMessage(DoomInfo.Strings.STSTR_MUS);
         }
-
-
 
         private class CheatInfo
         {

--- a/ManagedDoom/src/Doom/World/Cheat.cs
+++ b/ManagedDoom/src/Doom/World/Cheat.cs
@@ -37,7 +37,8 @@ namespace ManagedDoom
             new CheatInfo("killem", (cheat, typed) => cheat.KillMonsters(), false),
             new CheatInfo("fhhall", (cheat, typed) => cheat.KillMonsters(), false),
             new CheatInfo("idclev??", (cheat, typed) => cheat.ChangeLevel(typed), true),
-            new CheatInfo("idmus??", (cheat, typed) => cheat.ChangeMusic(typed), false)
+            new CheatInfo("idmus??", (cheat, typed) => cheat.ChangeMusic(typed), false),
+            new CheatInfo("idmypos", (cheat, typed) => cheat.ShowMyPosition(), false),
         };
 
         private static readonly int maxCodeLength = list.Max(info => info.Code.Length);
@@ -203,6 +204,11 @@ namespace ManagedDoom
         private void FullMap()
         {
             world.AutoMap.ToggleCheat();
+        }
+
+        private void ShowMyPosition()
+        {
+          ////
         }
 
         private void ShowPowerUpList()


### PR DESCRIPTION
Adds the "cheat" `IDMYPOS` to display the player's position in hexadecimal

* **Cheat Sequence:** `cheat_mypos_seq`
* **st_stuff.c:** [Reference Line 664](https://github.com/id-Software/DOOM/blob/a77dfb96cb91780ca334d0d4cfd86957558007e0/linuxdoom-1.10/st_stuff.c#L664)